### PR TITLE
SecureSignup Patch

### DIFF
--- a/sys-auth/app/backup/config.php.backup
+++ b/sys-auth/app/backup/config.php.backup
@@ -116,7 +116,7 @@ $final = [
 	],
 	'submit' => [
 		'login' => "https://{$x[2]}/login.php",
-		'signup' => ($config['use_https']) ? "https://securesignup.net/register2.php" : "http://order.{$x[0]}/register2.php"
+		'signup' => ($config['use_https']) ? "https://ifastnet.com/register2.php" : "http://order.{$x[0]}/register2.php"
 	],
 	'logo' => $config['logo'],
 	'email' => [

--- a/sys-auth/app/config.php
+++ b/sys-auth/app/config.php
@@ -116,7 +116,7 @@ $final = [
 	],
 	'submit' => [
 		'login' => "https://{$x[2]}/login.php",
-		'signup' => ($config['use_https']) ? "https://securesignup.net/register2.php" : "http://order.{$x[0]}/register2.php"
+		'signup' => ($config['use_https']) ? "https://ifastnet.com/register2.php" : "http://order.{$x[0]}/register2.php"
 	],
 	'logo' => $config['logo'],
 	'email' => [

--- a/sys-auth/signup.php
+++ b/sys-auth/signup.php
@@ -83,7 +83,7 @@ $csrf->createToken('register');
 						<div class="form-line">
 						    <input type="hidden" name="id" value="<?=$x[1];?>">
 						    <div>
-						    	<img width="320px" height="90px" src="https://securesignup.net/image.php?id=<?=$x[1];?>">
+						    	<img width="320px" height="90px" src="https://ifastnet.com/image.php?id=<?=$x[1];?>">
 						    </div>
 						    <br/>
 						    <div class="input-group">


### PR DESCRIPTION
As of today (?) SecureSignup.net is no longer resolving to the iFastNet website and as a result, the signup captcha is not displayed.

I replaced all instances of it with https://ifastnet.com, and so far it works. Please let me know if I missed anything or if it is not working as expected.