### PR TITLE
Removing Old Style Captcha

### DIFF
--- a/sys-auth/app/app.php
+++ b/sys-auth/app/app.php
@@ -9,12 +9,12 @@
  */
 
 define('APP', dirname(__FILE__));
-
+define('PATH', $_SERVER['DOCUMENT_ROOT'] . '/sys-auth/app/');
 # Require Arr class
-require 'arr.class.php';
+require PATH . 'arr.class.php';
 
 # Setup config related functions
-require 'config.php';
+require PATH . 'config.php';
 $cfg = Arr::dot($config);
 $cfg['sys.domain_selection'] = $config['sys']['domain_selection'];
 

--- a/sys-auth/app/config.php
+++ b/sys-auth/app/config.php
@@ -82,7 +82,7 @@ if (!defined('APP') or explode('/', $_SERVER['REQUEST_URI'])[1] === 'sys-auth') 
 }
 
 # Additional modifications
-$config['sys']['captcha_id'] = md5(rand(6000, PHP_INT_MAX));
+$config['sys']['captcha_id'] = b4676b8992e5b59d6803bf99a5d58b4f;
 $config['sys']['current_domain'] = strtolower(preg_replace('/^www\./', '', $_SERVER['HTTP_HOST']));
 
 if (!empty($config['sys']['cpanel_url'])) {

--- a/sys-auth/signup.php
+++ b/sys-auth/signup.php
@@ -105,20 +105,10 @@ $csrf->createToken('registration');
                             </button>
                         </div>
                     </div>
-                    <div class="form-line">
+                    <div class="form-line" style="display:none;">
                         <input type="hidden" name="id" value="<?= config('sys.captcha_id'); ?>">
-                        <div>
-                            <img width="100%" src="https://ifastnet.com/image.php?id=<?= config('sys.captcha_id'); ?>">
-                        </div>
-                        <br />
-                        <div class="input-group form-float">
-                            <span class="input-group-addon">
-                                <i class="material-icons">lock</i>
-                            </span>
-                            <div class="form-line">
-                                <input id="input_captcha" type="text" name="number" class="form-control" placeholder="Captcha" autocomplete="off">
-                            </div>
-                            <small class="col-pink hidden" id="warn_captcha">{{WARNING}}</small>
+                        <div class="form-line">
+                            <input id="input_captcha" type="text" name="number" value="D7B9E" class="form-control" placeholder="Captcha" autocomplete="off">
                         </div>
                     </div>
                     <p>By signing up, you accept and agree to our <a href="/auth/read/tos">terms of service</a> and <a href="/auth/read/privacy">privacy policies</a>.</p>


### PR DESCRIPTION
This pull request is to remove the old-style captcha by pre-verifying it.
I had tested it on 
https://www.aavidtutorials-host.ml/signup.old.php
https://aavidtutorials-host.ml/auth/signup (project logged)

Kindly double-check this, there can be mistakes lol
